### PR TITLE
Added JavaSound MIDI player

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -72,7 +72,9 @@ lazy val demo = crossProject
       |import compose.core._
       |import compose.examples._
       |import compose.player._
-    """.trim.stripMargin
+    """.trim.stripMargin,
+    fork in run := true,
+    connectInput in run := true
   )
 
 lazy val demoJVM = demo.jvm

--- a/demo/jvm/src/main/scala/compose/MidiMain.scala
+++ b/demo/jvm/src/main/scala/compose/MidiMain.scala
@@ -1,0 +1,35 @@
+package compose
+
+import compose.core._
+import compose.examples._
+import compose.player._
+import scala.concurrent.Await
+import scala.concurrent.duration.{Duration => Dur}
+import scala.concurrent.ExecutionContext.Implicits.global
+
+object MidiMain extends App {
+  case class MenuItem(number: String, name: String, score: Score) {
+    override def toString = s"$number. $name"
+  }
+
+  val menu = List(
+    MenuItem("1", "Duelling Banjos",    duellingBanjos),
+    MenuItem("2", "Chord Progression",  chordProgression),
+    MenuItem("3", "Scale",              scale(Pitch.C3.s) repeat 4),
+    MenuItem("4", "Scale With Echo",    withDelay(scale(Pitch.C3.s) repeat 4, Duration.Eighth.dotted)),
+    MenuItem("5", "Smoke On The Water", smokeOnTheWater),
+    MenuItem("6", "Twelve Bar Blues",   twelveBarBlues),
+    MenuItem("7", "Freebird!",          freebird),
+    MenuItem("8", "Scale With Overlap", withDelay(scale(Pitch.C3.h) repeat 2, Duration.Quarter.doubleDotted))
+  )
+
+  JavaSoundPlayer.withPlayer() { player =>
+    while (true) {
+      for (item <- menu) println(item)
+      val number = io.StdIn.readLine()
+      menu
+        .find(_.number == number)
+        .foreach(item => Await.result(player.play(item.score, Tempo(180)), Dur.Inf))
+    }
+  }
+}

--- a/player/jvm/src/main/scala/compose/player/JavaSoundPlayer.scala
+++ b/player/jvm/src/main/scala/compose/player/JavaSoundPlayer.scala
@@ -1,0 +1,104 @@
+package compose.player
+
+import compose.core._
+import javax.sound.midi._
+import java.util.{ Timer, TimerTask }
+import scala.concurrent.{ ExecutionContext => EC, _ }
+
+object JavaSoundPlayer {
+  def withPlayer[A]()(func: JavaSoundPlayer => A) = {
+    val player = new JavaSoundPlayer(MidiSystem.getSynthesizer)
+    try {
+      func(player)
+    } finally {
+      player.free
+    }
+  }
+
+  case class State(events: Seq[MidiEvent], currentTick: Long, playing: Map[Int, Pitch], tempo: Tempo)
+}
+
+class JavaSoundPlayer(synth: Synthesizer) extends Player[JavaSoundPlayer.State] {
+  import JavaSoundPlayer._
+  import Command._
+
+  val NOTE_ON_VELOCITY = 100
+  val NOTE_OFF_VELOCITY = 100
+  val MIDI_CONCERT_A = 69
+  val PAD_TIME = 1000 // extra time in msec to wait after sequence plays
+
+  def free: Unit =
+    synth.close()
+
+  def initialise: Future[State] =
+    Future.successful(State(Seq(), 1, Map.empty, Tempo()))
+
+  override def shutdown(state: State): Future[State] = {
+    // Durations are measured in 64th notes, so 16 divisions per beat (quarter note)
+    val sequence = new Sequence(Sequence.PPQ, 16)
+    val track = sequence.createTrack()
+    state.events foreach { track.add _ }
+
+    val sequencer = MidiSystem.getSequencer
+    if (sequencer == null) return Future.failed(new Exception("Unable to get MIDI sequencer"))
+
+    try {
+      sequencer.open()
+      synth.open()
+    } catch {
+      case e: MidiUnavailableException => return Future.failed(e)
+    }
+
+    sequencer.setSequence(sequence)
+    sequencer.setTempoInBPM(state.tempo.bpm)
+    sequencer.getTransmitter.setReceiver(synth.getReceiver)
+
+    val timer = new Timer()
+    val promise = Promise[State]
+    val task = new TimerTask {
+      def run(): Unit = {
+        sequencer.stop()
+        sequencer.close()
+        promise.success(state)
+      }
+    }
+    implicit val tempo = state.tempo
+    timer.schedule(task, PAD_TIME + tempo.milliseconds(Duration(state.currentTick.toInt)))
+    sequencer.start()
+    promise.future
+  }
+
+  def playCommand(state: State, cmd: Command)(implicit ec: EC, tempo: Tempo): Future[State] = {
+    cmd match {
+      case NoteOn(id, pitch) =>
+        val updated = state.playing + (id -> pitch)
+        
+        if (state.playing.values.toSeq contains pitch) {
+          // Ignore note on -- already playing
+          Future.successful(State(state.events, state.currentTick, updated, tempo))
+        } else {
+          val midiPitch = pitch.value + MIDI_CONCERT_A
+          val midiVelocity = NOTE_ON_VELOCITY
+          val event = new MidiEvent(new ShortMessage(ShortMessage.NOTE_ON, midiPitch, midiVelocity), state.currentTick)
+          Future.successful(State(state.events :+ event, state.currentTick, updated, tempo))
+        }
+
+      case NoteOff(id) =>
+        val pitch = state.playing(id)
+        val updated = state.playing - id
+        
+        if (updated.values.toSeq contains pitch) {
+          // Ignore note off -- still playing
+          Future.successful(State(state.events, state.currentTick, updated, tempo))
+        } else {
+          val midiPitch = pitch.value + MIDI_CONCERT_A
+          val midiVelocity = NOTE_OFF_VELOCITY
+          val event = new MidiEvent(new ShortMessage(ShortMessage.NOTE_OFF, midiPitch, midiVelocity), state.currentTick)
+          Future.successful(State(state.events :+ event, state.currentTick, updated, tempo))
+        }
+
+      case Wait(dur) =>
+        Future.successful(State(state.events, state.currentTick + dur.value, state.playing, tempo))
+    }
+  }
+}


### PR DESCRIPTION
I've been having trouble with the SuperCollider-based player, so I created a JavaSound (MIDI) version. It's pretty straightforward, except all the real work is done in the shutdown method -- up to that point, it just collects up a bunch of MidiEvents to be added to a Sequencer.

The MidiMain app is a variant of Main that uses the new player. It has one additional demo -- scales with overlap -- because one issue with MIDI is that I'm only using one channel and it doesn't like to have the same pitch turned on twice for overlapping notes. The player handles this case by only generating a NOTE ON message for the first of overlapping requests, and only generating a NOTE OFF for the last.

Two settings were added to build.sbt to run the demo in a forked JVM, because without forking the JavaSound devices don't work (see http://stackoverflow.com/questions/18676712/java-sound-devices-found-when-run-in-intellij-but-not-in-sbt).
